### PR TITLE
Add loading page

### DIFF
--- a/Web/package.json
+++ b/Web/package.json
@@ -15,6 +15,7 @@
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-router-dom": "^5.0.1",
+    "react-loading": "^2.0.3",
     "react-scripts": "3.2.0",
     "styled-components": "^4.4.0",
     "typescript": "3.6.4"

--- a/Web/src/Routes.tsx
+++ b/Web/src/Routes.tsx
@@ -1,10 +1,11 @@
 import React, { lazy, Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
+import Loading from './components/common/Loading';
 
 const LandingPage = lazy(() => import('./components/landing'));
 
 const Routes: React.FC = () => (
-  <Suspense fallback={<div>Loading...</div>}>
+  <Suspense fallback={<Loading />}>
     <Switch>
       <Route exact path="/" component={LandingPage} />
     </Switch>

--- a/Web/src/components/common/Loading.tsx
+++ b/Web/src/components/common/Loading.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactLoading from 'react-loading';
+import styled from 'styled-components';
+import { ReactComponent as PindaHeadSVG } from '../../svg/pinda-head-happy.svg';
+
+const LoadingDiv = styled.div`
+  background-color: var(--pale-purple);
+  height: 100vh;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const PindaHead = styled(PindaHeadSVG)`
+  height: 15vh;
+`;
+
+const Loading: React.FC = () => {
+  return (
+    <LoadingDiv>
+      <PindaHead />
+      <ReactLoading
+        type="bubbles"
+        color="var(--purple)"
+      />
+    </LoadingDiv>
+  );
+};
+
+export default Loading;

--- a/Web/src/components/common/Loading.tsx
+++ b/Web/src/components/common/Loading.tsx
@@ -21,10 +21,7 @@ const Loading: React.FC = () => {
   return (
     <LoadingDiv>
       <PindaHead />
-      <ReactLoading
-        type="bubbles"
-        color="var(--purple)"
-      />
+      <ReactLoading type="bubbles" color="var(--purple)" />
     </LoadingDiv>
   );
 };

--- a/Web/src/index.css
+++ b/Web/src/index.css
@@ -21,6 +21,9 @@ button {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   outline: none;
+}
+
+body {
   margin: 0;
 }
 

--- a/Web/yarn.lock
+++ b/Web/yarn.lock
@@ -8431,6 +8431,11 @@ react-router@5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-loading@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-loading/-/react-loading-2.0.3.tgz#e8138fb0c3e4674e481b320802ac7048ae14ffb9"
+  integrity sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==
+
 react-scripts@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-3.2.0.tgz#58ccd6b4ffa27f1b4d2986cbdcaa916660e9e33c"


### PR DESCRIPTION
### Changes
- Added a loading page with loader from `react-loading`
- Used this screen as fallback in #13 for suspense loading

#### Desktop Screenshot
<img width="1261" alt="Screenshot 2019-10-15 at 2 43 46 PM" src="https://user-images.githubusercontent.com/25261058/66807288-75448d00-ef5b-11e9-98ae-4dff85e5e826.png">

#### Mobile Screenshot
<img width="174" alt="Screenshot 2019-10-15 at 2 44 16 PM" src="https://user-images.githubusercontent.com/25261058/66807291-75448d00-ef5b-11e9-94b9-30e56b423aca.png">

### How to test
Remember to `yarn install` first.
Run `yarn start` to catch it before the landing page loads HAHA

OR

To see the screen by itself, import `Loading` into `App.tsx` and modify as follows:
```
import Loading from './components/common/Loading';

const App: React.FC = () => <Loading />;
```
Then run `yarn start` to see :)