### PR TITLE
Add join room page

### DIFF
--- a/Web/src/Routes.tsx
+++ b/Web/src/Routes.tsx
@@ -5,6 +5,7 @@ import RoomPage from './components/room/RoomPage';
 
 const LandingPage = lazy(() => import('./components/landing'));
 const CreateRoomPage = lazy(() => import('./components/create-room'));
+const JoinRoomPage = lazy(() => import('./components/join-room'));
 const BalloonShake = lazy(() => import('./games/BalloonShake'));
 
 const Routes: React.FC = () => (
@@ -12,6 +13,7 @@ const Routes: React.FC = () => (
     <Switch>
       <Route exact path="/" component={LandingPage} />
       <Route path="/new" component={CreateRoomPage} />
+      <Route path="/join" component={JoinRoomPage} />
       <Route exact path="/balloon-game" component={BalloonShake} />
       <Route exact path="/room" component={RoomPage} />
     </Switch>

--- a/Web/src/components/common/Loading.tsx
+++ b/Web/src/components/common/Loading.tsx
@@ -14,7 +14,7 @@ const LoadingDiv = styled.div`
 `;
 
 const PindaHead = styled(PindaHeadSVG)`
-  height: 15vh;
+  height: 5rem;
 `;
 
 const Loading: React.FC = () => (

--- a/Web/src/components/join-room/index.tsx
+++ b/Web/src/components/join-room/index.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import BigButton from '../common/BigButton';
+import { smMin } from '../../utils/media';
+import { ReactComponent as PindaHeadSVG } from '../../svg/pinda-head-happy.svg';
+
+const JoinRoomContainer = styled.div`
+  background: var(--pale-purple);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+
+  h1 {
+    font-family: var(--primary);
+    font-size: 1.4rem;
+    font-weight: normal;
+  }
+`;
+
+const PindaHead = styled(PindaHeadSVG)`
+  height: 5.5rem;
+`;
+
+const JoinRoomForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  & > * {
+    margin: 10px 0;
+  }
+`;
+
+const StyledInput = styled.input`
+  font-size: 3rem;
+  text-align: center;
+  background: none;
+  outline: none;
+  border: none;
+  border-bottom: 2px solid;
+  width: 13rem;
+  letter-spacing: 1rem;
+  padding: 0 0 0.5rem 1rem;
+  margin-bottom: 1.5rem;
+
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    display: none;
+    margin: 0;
+  }
+`;
+
+const JoinRoomButton = styled(BigButton)`
+  padding-left: 2em;
+  padding-right: 2em;
+`;
+
+const KeyboardArea = styled.div`
+  // Keyboard is approx 271px, buttons approx 60px
+  height: 211px;
+  display: none;
+
+  @media (max-width: ${smMin}) {
+    display: block;
+  }
+`;
+
+const JoinRoomPage: React.FC = () => {
+  const [gamePin, setGamePin] = useState('');
+
+  const onJoinRoomFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // TODO: Perform join room with gamePin
+  };
+
+  return (
+    <JoinRoomContainer>
+      <PindaHead />
+      <h1>Enter Game PIN</h1>
+      <JoinRoomForm onSubmit={onJoinRoomFormSubmit}>
+        <StyledInput
+          name="gamepin"
+          type="number"
+          placeholder="XXXX"
+          value={gamePin}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => (
+            setGamePin(event.target.value)
+          )}
+          required
+        />
+        <JoinRoomButton type="submit">Let&apos;s Go!</JoinRoomButton>
+        <Link to={{ pathname: '/' }}>Cancel</Link>
+      </JoinRoomForm>
+      <KeyboardArea />
+    </JoinRoomContainer>
+  );
+};
+
+export default JoinRoomPage;

--- a/Web/src/components/join-room/index.tsx
+++ b/Web/src/components/join-room/index.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import BigButton from '../common/BigButton';
-import { smMin } from '../../utils/media';
 import { ReactComponent as PindaHeadSVG } from '../../svg/pinda-head-happy.svg';
 
 const JoinRoomContainer = styled.div`
@@ -60,16 +59,6 @@ const JoinRoomButton = styled(BigButton)`
   padding-right: 2em;
 `;
 
-const KeyboardArea = styled.div`
-  // Keyboard is approx 271px, buttons approx 60px
-  height: 211px;
-  display: none;
-
-  @media (max-width: ${smMin}) {
-    display: block;
-  }
-`;
-
 const JoinRoomPage: React.FC = () => {
   const [gamePin, setGamePin] = useState('');
 
@@ -96,7 +85,6 @@ const JoinRoomPage: React.FC = () => {
         <JoinRoomButton type="submit">Let&apos;s Go!</JoinRoomButton>
         <Link to={{ pathname: '/' }}>Cancel</Link>
       </JoinRoomForm>
-      <KeyboardArea />
     </JoinRoomContainer>
   );
 };

--- a/Web/src/index.css
+++ b/Web/src/index.css
@@ -20,7 +20,8 @@
 
 body,
 div,
-button {
+button,
+input {
   font-family: var(--primary-font), sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
### Changes
Added static join room page.
Abit lazy to do PIN style text fields so this shall do for now HAHA
Will probably add a button on the landing page navbar to link to this screen (next PR?) so it's more easily accessed.

#### Desktop screenshot
![screencapture-localhost-3000-join-2019-10-17-21_15_16](https://user-images.githubusercontent.com/25261058/67012664-5cd39e80-f124-11e9-87bc-0f9025531df1.png)

#### Mobile screenshot
![screencapture-localhost-3000-join-2019-10-17-21_15_37](https://user-images.githubusercontent.com/25261058/67012660-5ba27180-f124-11e9-801c-37fa0c8185b9.png)

###  How to test
Go to [`/join`](https://deploy-preview-36--pinda-fun.netlify.com/join) to see this screen.