### PR TITLE
Fix pin input for join page

### DIFF
--- a/Web/src/components/common/BigButton.tsx
+++ b/Web/src/components/common/BigButton.tsx
@@ -15,10 +15,16 @@ const BigButton = styled.button`
 
   transition: 0.2s;
 
-  :hover,
-  :active {
+  :hover:enabled,
+  :active:enabled {
     transform: translateY(6px);
     box-shadow: 0px 0px 0px var(--dark-purple);
+  }
+
+  :disabled {
+    cursor: not-allowed;
+    background: darkgrey;
+    box-shadow: 0px 6px 0px grey;
   }
 `;
 

--- a/Web/src/components/join-room/index.tsx
+++ b/Web/src/components/join-room/index.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import BigButton from '../common/BigButton';
 import { ReactComponent as PindaHeadSVG } from '../../svg/pinda-head-happy.svg';
 
+const PIN_LENGTH = 4;
+
 const JoinRoomContainer = styled.div`
   background: var(--pale-purple);
   min-height: 100vh;
@@ -46,12 +48,6 @@ const StyledInput = styled.input`
   letter-spacing: 1rem;
   padding: 0 0 0.5rem 1rem;
   margin-bottom: 1.5rem;
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    display: none;
-    margin: 0;
-  }
 `;
 
 const JoinRoomButton = styled(BigButton)`
@@ -74,15 +70,19 @@ const JoinRoomPage: React.FC = () => {
       <JoinRoomForm onSubmit={onJoinRoomFormSubmit}>
         <StyledInput
           name="gamepin"
-          type="number"
+          type="text"
+          pattern="[0-9]*"
+          inputMode="numeric"
+          maxLength={PIN_LENGTH}
           placeholder="XXXX"
           value={gamePin}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => (
-            setGamePin(event.target.value)
+            setGamePin(event.target.value.replace(/\D/g, ''))
           )}
-          required
         />
-        <JoinRoomButton type="submit">Let&apos;s Go!</JoinRoomButton>
+        <JoinRoomButton type="submit" disabled={gamePin.length < PIN_LENGTH}>
+          Let&apos;s Go!
+        </JoinRoomButton>
         <Link to={{ pathname: '/' }}>Cancel</Link>
       </JoinRoomForm>
     </JoinRoomContainer>


### PR DESCRIPTION
omg form inputs are a pain. 
- Changed `type="number"` to `type="text"` so no more ugly spin box
- Made `/join` page PIN input trigger numeric keyboard
- Max length 4 for PIN
- Only allow numeric input
- Disable "Let's go!" button when length of input < 4