### PR TITLE
Fix font rendering by increasing line height

### DIFF
--- a/Web/src/components/games/BalloonShake/GameDisplay.tsx
+++ b/Web/src/components/games/BalloonShake/GameDisplay.tsx
@@ -35,7 +35,9 @@ const TimeLeft = styled.h2`
   color: var(--purple);
   margin: 0 0 0 0;
   justify-content: center;
-  padding-top: 6px;
+
+  // Increase line-height to curb font rendering bug
+  line-height: 1.2;
 `;
 
 const ShakeCount = styled.h3`
@@ -43,7 +45,9 @@ const ShakeCount = styled.h3`
   color: var(--dark-purple);
   margin: 1rem 0 0 0;
   justify-content: center;
-  padding-top: 6px;
+
+  // Increase line-height to curb font rendering bug
+  line-height: 1.2;
 `;
 
 const GameDisplay: React.FC<IProps> = ({ secondsLeft, count }) => (

--- a/Web/src/components/games/Countdown.tsx
+++ b/Web/src/components/games/Countdown.tsx
@@ -17,8 +17,8 @@ const Text = styled.h1`
   color: white;
   text-shadow: 10px 10px 0px rgba(0, 0, 0, 0.1);
 
-  // Add padding to curb font rendering bug
-  padding-top: 2rem;
+  // Increase line-height to curb font rendering bug
+  line-height: 1.2;
 `;
 
 type CountdownProps = {


### PR DESCRIPTION
### Changes
Increased line height of places Luckiest Guy font is used for counters

#### Reason
This font's offset is weirdly set, and the entire font does not sit within it's line height (the blue box) as seen in the image below. 
<img width="83" alt="Screenshot 2019-10-21 at 2 46 20 PM" src="https://user-images.githubusercontent.com/25261058/67182392-a4527700-f411-11e9-9553-913ca1ada4cf.png">
This results in weird behaviour such as phone screens only re-rendering the area within the blue box, leaving weird pixels behind when counting down.
Increased the line height in an attempt to prevent this weird behaviour. Previously, we used `padding-top` but that seems more hackish than this method.

### How to test
Open up https://deploy-preview-69--pinda-fun.netlify.com/balloon-game on your phone and ensure that you don't see any random pixels leftover when counting down.
- [x] verified to work on my phone