### PR TITLE
Create context from useErrorableChannel

### DIFF
--- a/Web/src/Routes.tsx
+++ b/Web/src/Routes.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
+import ChannelContext, { useUncontrolledErrorableChannel } from 'components/room/ChannelContext';
 import Loading from './components/common/Loading';
-import ChannelContext, { useControlledErrorableChannel } from 'components/room/ChannelContext';
 
 const LandingPage = lazy(() => import('components/landing'));
 const CreateRoomPage = lazy(() => import('components/create-room'));
@@ -9,7 +9,7 @@ const JoinRoomPage = lazy(() => import('components/join-room'));
 const BalloonShake = lazy(() => import('components/games/BalloonShake'));
 
 const RoutesWithChannelContext: React.FC = () => (
-  <ChannelContext.Provider value={useControlledErrorableChannel()}>
+  <ChannelContext.Provider value={useUncontrolledErrorableChannel()}>
     <Switch>
       <Route path="/new" component={CreateRoomPage} />
       <Route exact path="/join" component={JoinRoomPage} />

--- a/Web/src/Routes.tsx
+++ b/Web/src/Routes.tsx
@@ -1,20 +1,29 @@
 import React, { lazy, Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import Loading from './components/common/Loading';
+import ChannelContext, { useControlledErrorableChannel } from 'components/room/ChannelContext';
 
 const LandingPage = lazy(() => import('components/landing'));
 const CreateRoomPage = lazy(() => import('components/create-room'));
 const JoinRoomPage = lazy(() => import('components/join-room'));
 const BalloonShake = lazy(() => import('components/games/BalloonShake'));
 
-const Routes: React.FC = () => (
-  <Suspense fallback={<Loading />}>
+const RoutesWithChannelContext: React.FC = () => (
+  <ChannelContext.Provider value={useControlledErrorableChannel()}>
     <Switch>
-      <Route exact path="/" component={LandingPage} />
       <Route path="/new" component={CreateRoomPage} />
       <Route exact path="/join" component={JoinRoomPage} />
       <Route path="/join/:id" component={JoinRoomPage} />
       <Route exact path="/balloon-game" component={BalloonShake} />
+    </Switch>
+  </ChannelContext.Provider>
+);
+
+const Routes: React.FC = () => (
+  <Suspense fallback={<Loading />}>
+    <Switch>
+      <Route exact path="/" component={LandingPage} />
+      <RoutesWithChannelContext />
     </Switch>
   </Suspense>
 );

--- a/Web/src/components/create-room/index.tsx
+++ b/Web/src/components/create-room/index.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import useErrorableChannel from 'components/room/hooks/useErrorableChannel';
 import BigButton from 'components/common/BigButton';
 import Loading from 'components/common/Loading';
+import ChannelContext, { UncontrolledErrorableChannelProps } from 'components/room/ChannelContext';
 import NumPlayers from './NumPlayers';
 import SocialShare from './SocialShare';
 import QrCode from './QrCode';
@@ -124,11 +124,17 @@ const CreateRoomPage: React.FC = () => {
   const [numPlayers, setNumPlayers] = useState(0);
 
   const {
-    channel, error, returnPayload, database,
-  } = useErrorableChannel<Payload | {}, LobbyReturnPayload | {}>(
-    pin == null ? 'room:lobby' : `room:${pin}`,
-    pin == null ? {} : { name: 'Julius', game: 'Shake' },
-  );
+    channel, error, returnPayload, database, setChannel,
+  } = useContext(ChannelContext) as
+    UncontrolledErrorableChannelProps<Payload | {}, LobbyReturnPayload | {}>;
+
+  useEffect(() => {
+    setChannel(
+      pin == null ? 'room:lobby' : `room:${pin}`,
+      pin == null ? {} : { name: 'Julius', game: 'Shake' },
+    );
+  }, [pin, setChannel]);
+
   const [names, setNames] = useState<[string, string][]>([]);
 
   const sharableLink = `${window.location.origin}/join/${pin}`;

--- a/Web/src/components/join-room/index.tsx
+++ b/Web/src/components/join-room/index.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { match } from 'react-router-dom';
 import styled from 'styled-components';
 import Modal from 'components/common/Modal';
 import { MotionPermission } from 'components/games/BalloonShake/GameStates';
-import useErrorableChannel from 'components/room/hooks/useErrorableChannel';
+import ChannelContext from 'components/room/ChannelContext';
 import { ReactComponent as PindaHeadSVG } from '../../svg/pinda-head-happy.svg';
 import JoinRoomForm from './JoinRoomForm';
 
@@ -51,7 +51,9 @@ const JoinRoomPage: React.FC<JoinRoomProps> = ({
   const [numPlayers, setNumPlayers] = useState(0);
 
   const [channelName, setChannelName] = useState<string | null>(null);
-  const { channel, error, database } = useErrorableChannel(channelName, { name });
+  const {
+    channel, error, database, setChannel,
+  } = useContext(ChannelContext);
 
   const getUserPermission = async function requestPermission() {
     try {
@@ -93,6 +95,11 @@ const JoinRoomPage: React.FC<JoinRoomProps> = ({
 
     setGamePin(newGamePin);
   };
+
+  useEffect(() => {
+    if (channelName === null) return;
+    setChannel(channelName, { name });
+  }, [name, channelName, setChannel]);
 
   useEffect(() => {
     if (joinRequested && permission === MotionPermission.NOT_SET) {

--- a/Web/src/components/join-room/index.tsx
+++ b/Web/src/components/join-room/index.tsx
@@ -30,11 +30,6 @@ const PindaHead = styled(PindaHeadSVG)`
   height: 5.5rem;
 `;
 
-
-interface Payload {
-  name: string,
-}
-
 type JoinRoomProps = {
   match: match<{ id?: string }>;
 };

--- a/Web/src/components/room/ChannelContext.ts
+++ b/Web/src/components/room/ChannelContext.ts
@@ -1,0 +1,40 @@
+import React, { useState, createContext, Context } from 'react';
+import useErrorableChannel from './hooks/useErrorableChannel';
+import { Channel } from 'phoenix';
+import ErrorCause from './hooks/ErrorCause';
+
+type ChannelConnectionArgs<T> = [string | null, T];
+
+interface Payload {
+  name: string,
+}
+
+interface ControlledErrorableChannelProps<T> {
+  channel: Channel | null;
+  error: [ErrorCause, any] | null;
+  returnPayload: any;
+  database: any;
+  setArgs: React.Dispatch<React.SetStateAction<ChannelConnectionArgs<T>>>
+};
+
+const emptyChannelArgs: ChannelConnectionArgs<{}> = [null, {}];
+
+export const useControlledErrorableChannel = function <T extends object>() {
+  const [args, setArgs] = useState<ChannelConnectionArgs<T>>(
+    emptyChannelArgs as ChannelConnectionArgs<T>
+  );
+
+  const {
+    channel, error, returnPayload, database
+  } = useErrorableChannel(...args);
+
+  return {
+    channel, error, returnPayload, database, setArgs
+  }
+};
+
+const ChannelContext: Context<ControlledErrorableChannelProps<Payload>> = createContext(
+  (undefined as unknown) as ControlledErrorableChannelProps<Payload>
+);
+
+export default ChannelContext;


### PR DESCRIPTION
# Motivation
We would need to use the channel hook as a persistent state across components/pages. We can either initialise the state in a parent component and pass them around, or use context.

# Design considerations
- I tried to touch existing implementations & usages of `useErrorableChannel` as little as possible, and I did this by wrapping the hook within my own hook that provides a mutating function (`setChannel(channelId: string, payload: T)`) for context consumers to use. Should we just rewrite `useErrorableChannel`?

# Tests
- [x] Make sure they work with existing room operations
- [x] Make sure that teardowns between context loads are working properly
- [x] Make sure persistence of channel states between component loads
- [x] Load/reload on channel entry & exits (changing channels, changing components) - I'll check this when I implement transitions between room entry & exit