### PR TITLE
Add join room with username

### DIFF
--- a/Web/src/components/common/LinkButton.tsx
+++ b/Web/src/components/common/LinkButton.tsx
@@ -1,0 +1,18 @@
+import styled, { css } from 'styled-components';
+
+type ButtonProps = {
+  underline?: boolean;
+};
+
+const LinkButton = styled.button`
+  background: transparent;
+  color: var(--dark-purple);
+  font-size: 1rem;
+
+  ${(props: ButtonProps) => props.underline
+    && css`
+      text-decoration: underline;
+    `};
+`;
+
+export default LinkButton;

--- a/Web/src/components/join-room/FormElements.tsx
+++ b/Web/src/components/join-room/FormElements.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import BigButton from 'components/common/BigButton';
+
+const SubmitButton = styled(BigButton)`
+  padding-left: 2em;
+  padding-right: 2em;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  & > * {
+    margin: 10px 0;
+  }
+`;
+
+export {
+  Form,
+  SubmitButton,
+};

--- a/Web/src/components/join-room/GamePinForm.tsx
+++ b/Web/src/components/join-room/GamePinForm.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { MotionPermission } from 'components/games/GameStates';
+import { Form, SubmitButton } from './FormElements';
+
+const StyledPinInput = styled.input`
+  font-size: 3rem;
+  letter-spacing: 1rem;
+  text-align: center;
+
+  background: none;
+  outline: none;
+  border-bottom: 2px solid;
+  width: 13rem;
+  padding: 0 0 0.5rem 1rem;
+  margin-bottom: 1.5rem;
+`;
+
+interface GamePinFormProps {
+  onSubmitPin: (gamePin: string) => void;
+  pinLength: number;
+  initialPin: string;
+  permission: MotionPermission;
+}
+
+const GamePinForm: React.FC<GamePinFormProps> = ({
+  onSubmitPin,
+  pinLength,
+  initialPin,
+  permission,
+}) => {
+  const [gamePin, setGamePin] = useState(initialPin);
+
+  return (
+    <Form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmitPin(gamePin);
+      }}
+    >
+      <h1>Enter Game PIN</h1>
+      <StyledPinInput
+        name="gamepin"
+        type="text"
+        pattern="[0-9]*"
+        inputMode="numeric"
+        maxLength={pinLength}
+        placeholder="XXXX"
+        value={gamePin}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => (
+          setGamePin(event.target.value.replace(/\D/g, ''))
+        )}
+        autoFocus
+      />
+      <SubmitButton
+        type="submit"
+        disabled={gamePin.length < pinLength
+          || permission === MotionPermission.DENIED}
+      >
+        Next
+      </SubmitButton>
+    </Form>
+  );
+};
+
+export default GamePinForm;

--- a/Web/src/components/join-room/JoinRoomForm.tsx
+++ b/Web/src/components/join-room/JoinRoomForm.tsx
@@ -1,91 +1,78 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import BigButton from 'components/common/BigButton';
+import LinkButton from 'components/common/LinkButton';
 import { MotionPermission } from 'components/games/GameStates';
-
-const PIN_LENGTH = 4;
-
-const StyledInput = styled.input`
-  font-size: 3rem;
-  text-align: center;
-  background: none;
-  outline: none;
-  border-bottom: 2px solid;
-  width: 13rem;
-  letter-spacing: 1rem;
-  padding: 0 0 0.5rem 1rem;
-  margin-bottom: 1.5rem;
-`;
-
-const JoinRoomButton = styled(BigButton)`
-  padding-left: 2em;
-  padding-right: 2em;
-`;
-
-const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-
-  & > * {
-    margin: 10px 0;
-  }
-`;
+import GamePinForm from './GamePinForm';
+import UsernameForm from './UsernameForm';
 
 const ErrorText = styled.p`
   color: red;
 `;
 
 interface JoinRoomFormProps {
-  submitJoinRoomForm: (roomId: string) => void;
+  submitJoinRoomForm: (roomId: string, username: string) => void;
   initialId?: string;
+  pinLength: number;
   permission: MotionPermission;
 }
 
 const JoinRoomForm: React.FC<JoinRoomFormProps> = ({
-  submitJoinRoomForm, initialId, permission,
+  submitJoinRoomForm,
+  initialId,
+  pinLength,
+  permission,
 }) => {
-  const [gamePin, setGamePin] = useState(initialId ? initialId.substring(0, PIN_LENGTH) : '');
+  const [isGamePinSet, setIsGamePinSet] = useState(false);
+
+  let gamePin = initialId ? initialId.substring(0, pinLength) : '';
+  let username = '';
+
+  const handleSubmitGamePin = (pin: string) => {
+    gamePin = pin;
+    setIsGamePinSet(true);
+  };
+
+  const handleSubmitUsername = (name: string) => {
+    username = name;
+    submitJoinRoomForm(gamePin, username);
+  };
 
   return (
     <>
-      <h1>Enter Game PIN</h1>
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submitJoinRoomForm(gamePin);
-        }}
-      >
-        <StyledInput
-          name="gamepin"
-          type="text"
-          pattern="[0-9]*"
-          inputMode="numeric"
-          maxLength={PIN_LENGTH}
-          placeholder="XXXX"
-          value={gamePin}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) => (
-            setGamePin(event.target.value.replace(/\D/g, ''))
-          )}
-          autoFocus
-        />
-        <JoinRoomButton
-          type="submit"
-          disabled={gamePin.length < PIN_LENGTH
-            || permission === MotionPermission.DENIED}
-        >
-          Let&apos;s Go!
-        </JoinRoomButton>
-        {permission === MotionPermission.DENIED
-          && (
-            <ErrorText>
-              Unable to get permissions to play Pinda.
-            </ErrorText>
-          )}
-        <Link to={{ pathname: '/' }}>Cancel</Link>
-      </Form>
+      {!isGamePinSet
+        && (
+          <>
+            <GamePinForm
+              onSubmitPin={handleSubmitGamePin}
+              pinLength={pinLength}
+              initialPin={gamePin}
+              permission={permission}
+            />
+            <Link to={{ pathname: '/' }}>Cancel</Link>
+          </>
+        )}
+      {isGamePinSet
+        && (
+          <>
+            <UsernameForm
+              onSubmitName={handleSubmitUsername}
+              permission={permission}
+            />
+            <LinkButton
+              underline
+              onClick={() => setIsGamePinSet(false)}
+            >
+              Back
+            </LinkButton>
+          </>
+        )}
+      {permission === MotionPermission.DENIED
+        && (
+          <ErrorText>
+            Unable to get permissions to play Pinda.
+          </ErrorText>
+        )}
     </>
   );
 };

--- a/Web/src/components/join-room/UsernameForm.tsx
+++ b/Web/src/components/join-room/UsernameForm.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { MotionPermission } from 'components/games/GameStates';
+import { Form, SubmitButton } from './FormElements';
+
+const StyledNameInput = styled.input`
+  font-size: 1.8rem;
+
+  background: none;
+  outline: none;
+  border-bottom: 2px solid;
+  width: 13rem;
+  padding: 0 0 0.5rem 1rem;
+  margin-bottom: 1.5rem;
+`;
+
+type UsernameFormProps = {
+  onSubmitName: (name: string) => void;
+  permission: MotionPermission;
+};
+
+const UsernameForm: React.FC<UsernameFormProps> = ({
+  onSubmitName,
+  permission,
+}) => {
+  const [name, setName] = useState('');
+
+  return (
+    <Form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmitName(name);
+      }}
+    >
+      <h1>Enter Name</h1>
+      <StyledNameInput
+        name="username"
+        type="text"
+        placeholder="eg. Ben Leong"
+        value={name}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => (
+          setName(event.target.value.replace(/[^a-z0-9 ]/gi, ''))
+        )}
+        autoFocus
+      />
+      <SubmitButton
+        type="submit"
+        disabled={name === ''
+          || permission === MotionPermission.DENIED}
+      >
+        Let&apos;s Go!
+      </SubmitButton>
+    </Form>
+  );
+};
+
+export default UsernameForm;

--- a/Web/src/components/join-room/index.tsx
+++ b/Web/src/components/join-room/index.tsx
@@ -41,6 +41,7 @@ const JoinRoomPage: React.FC<JoinRoomProps> = ({
   },
 }) => {
   const [gamePin, setGamePin] = useState(id ? id.substring(0, PIN_LENGTH) : '');
+  const [username, setUsername] = useState('');
 
   const [permission, setPermission] = useState(MotionPermission.NOT_SET);
   const [showPermissionDialog, setPermissionDialog] = useState(false);
@@ -80,13 +81,15 @@ const JoinRoomPage: React.FC<JoinRoomProps> = ({
     }
   };
 
-  const onJoinRoomFormSubmit = (newGamePin: string) => {
+  const onJoinRoomFormSubmit = (newGamePin: string, newUsername: string) => {
     if (joinRequested && newGamePin === gamePin) return;
     if (newGamePin.length !== PIN_LENGTH) return;
+    if (newUsername === '') return;
 
     setJoinRequested(true);
 
     setGamePin(newGamePin);
+    setUsername(newUsername);
   };
 
   useEffect(() => {
@@ -94,17 +97,11 @@ const JoinRoomPage: React.FC<JoinRoomProps> = ({
       getPermissionAvailability();
     }
     if (joinRequested && permission === MotionPermission.GRANTED) {
-      const name = prompt('What is your name?');
-      if (name == null || name === '') {
-        alert('Name cannot be empty');
-        setJoinRequested(false);
-        return undefined;
-      }
-      comm.joinRoom(gamePin, name);
+      comm.joinRoom(gamePin, username);
       return () => comm.leaveRoom();
     }
     return undefined;
-  }, [permission, joinRequested, gamePin, comm]);
+  }, [permission, joinRequested, gamePin, username, comm]);
 
   useEffect(() => {
     if (error != null) setJoinRequested(false);
@@ -116,15 +113,16 @@ const JoinRoomPage: React.FC<JoinRoomProps> = ({
       <JoinRoomForm
         submitJoinRoomForm={onJoinRoomFormSubmit}
         initialId={id}
+        pinLength={PIN_LENGTH}
         permission={permission}
       />
-      <p>{room != null && `Connected, numPlayers = ${users.length}`}</p>
       <p>
+        {room != null && `Connected, numPlayers = ${users.length}`}
         {error != null && `Error: ${error.toString()} -- ${errorDescription}`}
+        {room != null && hostMeta == null && 'Host left us :('}
+        {hostMeta != null && `Game: ${hostMeta.game}`}
+        Users: {JSON.stringify(users)}
       </p>
-      <p>{room != null && hostMeta == null && 'Host left us :('}</p>
-      <p>{hostMeta != null && `Game: ${hostMeta.game}`}</p>
-      <p>Users: {JSON.stringify(users)}</p>
       <Modal
         isVisible={showPermissionDialog}
         title="Give Permissions?"


### PR DESCRIPTION
Change username alert to a next screen after keying in room pin

Chose this approach over having username and room pin on the same page due to:
- aesthetics
- on phone, when the keyboard is automatically triggered, there would be a lot more scrolling. 
- the keyboards are autofocused anyway so you kinda go to the next keyboard immediately after clicking next
- you can immediately show the user feedback on the fields (such as enabling the button after 4 digits of pin is keyed in)

Possible improvements not in this PR:
- reflect the room pin in the username form page
- reflect username of user in game screens? 