### PR TITLE
Randomise game in each round and various frontend cleanups

### DIFF
--- a/Web/src/components/common/Loading.tsx
+++ b/Web/src/components/common/Loading.tsx
@@ -17,10 +17,11 @@ const PindaHead = styled(PindaHeadSVG)`
   height: 5rem;
 `;
 
-const Loading: React.FC = () => (
+const Loading: React.FC = ({ children }) => (
   <LoadingDiv>
     <PindaHead />
     <ReactLoading type="bubbles" color="var(--purple)" />
+    {children}
   </LoadingDiv>
 );
 

--- a/Web/src/components/create-room/HostRoom.tsx
+++ b/Web/src/components/create-room/HostRoom.tsx
@@ -113,14 +113,14 @@ const PindaHappy = styled(PindaHappySVG)`
 `;
 
 const HostRoomLobby: React.FC<FinishedComponentProps> = ({
-  room, error, users, results,
+  room, error, users, results, game,
 }) => {
   const comm = useContext(CommContext);
 
   const onStartButtonClick = () => {
-    const allGames = Object.values(Game) as Game[];
-    const game = allGames[Math.floor(Math.random() * allGames.length)];
-    comm.changeGame(game, () => comm.prepare());
+    const allGames = Object.values(Game).filter((value) => value !== game.toString()) as Game[];
+    const nextGame = allGames[Math.floor(Math.random() * allGames.length)];
+    comm.changeGame(nextGame, () => comm.prepare());
   };
 
   const sharableLink = `${window.location.origin}/join/${room}`;

--- a/Web/src/components/create-room/HostRoom.tsx
+++ b/Web/src/components/create-room/HostRoom.tsx
@@ -141,8 +141,8 @@ const HostRoomLobby: React.FC<FinishedComponentProps> = ({
       {resultsExist(results) && (
         <>
           <h1>Last Game:</h1>
-          {Object.entries(results).map(([name, score]) => (
-            <p>{name}: {score}</p>
+          {Object.entries(results).map(([clientId, { name, result }]) => (
+            <p key={clientId}>{name}: {result}</p>
           ))}
         </>
       )}

--- a/Web/src/components/create-room/HostRoom.tsx
+++ b/Web/src/components/create-room/HostRoom.tsx
@@ -113,7 +113,7 @@ const PindaHappy = styled(PindaHappySVG)`
 `;
 
 const HostRoomLobby: React.FC<FinishedComponentProps> = ({
-  room, error, users, results, game,
+  room, error, users, allMetas, game,
 }) => {
   const comm = useContext(CommContext);
 
@@ -138,10 +138,10 @@ const HostRoomLobby: React.FC<FinishedComponentProps> = ({
 
   return (
     <CreateRoomContainer>
-      {resultsExist(results) && (
+      {resultsExist(allMetas) && (
         <>
           <h1>Last Game:</h1>
-          {Object.entries(results).map(([clientId, { name, result }]) => (
+          {Object.entries(allMetas).map(([clientId, { name, result }]) => (
             <p key={clientId}>{name}: {result}</p>
           ))}
         </>

--- a/Web/src/components/create-room/HostRoom.tsx
+++ b/Web/src/components/create-room/HostRoom.tsx
@@ -5,6 +5,7 @@ import BigButton from 'components/common/BigButton';
 import CommContext from 'components/room/comm/CommContext';
 import CommonRoom, { FinishedComponentProps } from 'components/room/CommonRoom';
 import { resultsExist } from 'components/room/comm/Comm';
+import Game from 'components/room/Games';
 import NumPlayers from './NumPlayers';
 import SocialShare from './SocialShare';
 import QrCode from './QrCode';
@@ -116,6 +117,12 @@ const HostRoomLobby: React.FC<FinishedComponentProps> = ({
 }) => {
   const comm = useContext(CommContext);
 
+  const onStartButtonClick = () => {
+    const allGames = Object.values(Game) as Game[];
+    const game = allGames[Math.floor(Math.random() * allGames.length)];
+    comm.changeGame(game, () => comm.prepare());
+  };
+
   const sharableLink = `${window.location.origin}/join/${room}`;
 
   // TODO: stylise error
@@ -157,7 +164,7 @@ const HostRoomLobby: React.FC<FinishedComponentProps> = ({
         </ShareSection>
       </TwoColumnDiv>
       <StartButton
-        onClick={() => comm.prepare()}
+        onClick={onStartButtonClick}
       >
         START!
       </StartButton>

--- a/Web/src/components/games/PandaSequence/GameDisplay.tsx
+++ b/Web/src/components/games/PandaSequence/GameDisplay.tsx
@@ -12,7 +12,7 @@ interface IProps {
   mode: PandaSequenceMode,
   secondsLeft: number,
   score: number,
-  processInput:(input:number) => boolean,
+  processInput: (input: number) => boolean,
   feedback: Feedback,
   timestep: number,
   displaying?: number,
@@ -27,7 +27,7 @@ const InputTheme = {
 };
 
 interface GameContainerProps extends React.HTMLAttributes<HTMLDivElement> {
-  feedbackState:Feedback;
+  feedbackState: Feedback;
 }
 
 /**
@@ -53,7 +53,7 @@ const GameContainer = styled(GameContainerElement)`
   font-size: 1.4rem;
   text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.1);
 
-  ${({ feedbackState }:GameContainerProps) => (feedbackState === Feedback.CORRECT && css`animation: ${blinkGreen} 0.5s ease-in-out 0s 1;`)
+  ${({ feedbackState }: GameContainerProps) => (feedbackState === Feedback.CORRECT && css`animation: ${blinkGreen} 0.5s ease-in-out 0s 1;`)
     || (feedbackState === Feedback.WRONG && css`animation: ${blinkRed} 0.5s ease-in-out 0s 1;`)
 }
 `;
@@ -118,20 +118,18 @@ const GameDisplay: React.FC<IProps> = ({
   let pots;
   if (mode === PandaSequenceMode.DISPLAY) {
     pots = Array(NUM_POTS).fill(null).map((_, index) => (
-      <FlowerPotDiv>
+      // eslint-disable-next-line react/no-array-index-key
+      <FlowerPotDiv key={index}>
         <DisplayPandaPot
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
           duration={displaying === index ? timestep : 0}
         />
       </FlowerPotDiv>
     ));
   } else {
     pots = Array(NUM_POTS).fill(null).map((_, index) => (
-      <FlowerPotDiv>
+      // eslint-disable-next-line react/no-array-index-key
+      <FlowerPotDiv key={index}>
         <InputPandaPot
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
           onTouch={(event: React.SyntheticEvent) => handleTouch(event, index)}
           onTouchEnd={(event: React.SyntheticEvent) => handleTouchEnd(event, index)}
           isSelected={selected[index]}

--- a/Web/src/components/room/CommonRoom.tsx
+++ b/Web/src/components/room/CommonRoom.tsx
@@ -61,6 +61,9 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
   useEffect(() => {
     if (hostMeta === null) return;
     setGame(hostMeta.game);
+    if (hostMeta.state === GameState.FINISHED) {
+      setIsReady(false);
+    }
   }, [hostMeta]);
 
   if (hostMeta === null) {
@@ -81,10 +84,10 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
         && <GameComponent game={game} />}
       {hostMeta.state === GameState.PREPARE
         && (
-        <Loading>
-          {isReady && <p>You are ready!</p>}
-          {!isReady && <BigButton onClick={onReadyClick}>I am ready!</BigButton>}
-        </Loading>
+          <Loading>
+            {isReady && <p>You are ready!</p>}
+            {!isReady && <BigButton onClick={onReadyClick}>I am ready!</BigButton>}
+          </Loading>
         )}
     </>
   );

--- a/Web/src/components/room/CommonRoom.tsx
+++ b/Web/src/components/room/CommonRoom.tsx
@@ -4,6 +4,7 @@ import React, {
 import CommContext from 'components/room/comm/CommContext';
 import useCommHooks from 'components/room/comm/useCommHooks';
 import Loading from 'components/common/Loading';
+import BigButton from 'components/common/BigButton';
 import GameState from './comm/GameState';
 import Game from './Games';
 import { CommError } from './comm/Errors';
@@ -43,6 +44,7 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
 }) => {
   const comm = useContext(CommContext);
   const [game, setGame] = useState(Game.SHAKE);
+  const [isReady, setIsReady] = useState(false);
 
   // general hook to disconnect host from room when he leaves.
   useEffect(() => () => comm.leaveRoom(), [comm]);
@@ -50,6 +52,11 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
   const {
     hostMeta, room, error, users, results,
   } = useCommHooks(comm);
+
+  const onReadyClick = () => {
+    comm.readyUp();
+    setIsReady(true);
+  };
 
   useEffect(() => {
     if (hostMeta === null) return;
@@ -73,7 +80,12 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
       {hostMeta.state === GameState.ONGOING
         && <GameComponent game={game} />}
       {hostMeta.state === GameState.PREPARE
-        && <Loading />}
+        && (
+        <Loading>
+          {isReady && <p>You are ready!</p>}
+          {!isReady && <BigButton onClick={onReadyClick}>I am ready!</BigButton>}
+        </Loading>
+        )}
     </>
   );
 };

--- a/Web/src/components/room/CommonRoom.tsx
+++ b/Web/src/components/room/CommonRoom.tsx
@@ -52,7 +52,7 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
   }, [comm]);
 
   const {
-    hostMeta, room, error, users, results, isHost,
+    hostMeta, room, error, users, results, myMeta,
   } = useCommHooks(comm);
 
   const onReadyClick = () => {
@@ -62,14 +62,15 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
 
   useEffect(() => {
     if (hostMeta === null) {
-      if (isHost && room !== null) comm.leaveRoom();
+      // If host left, leave the room
+      if (myMeta !== null && !myMeta.isHost && room !== null) comm.leaveRoom();
       return;
     }
     setGame(hostMeta.game);
     if (hostMeta.state === GameState.FINISHED) {
       setIsReady(false);
     }
-  }, [comm, hostMeta, isHost, room]);
+  }, [comm, hostMeta, myMeta, room]);
 
   if (hostMeta === null) {
     return <NoHostComponent />;

--- a/Web/src/components/room/CommonRoom.tsx
+++ b/Web/src/components/room/CommonRoom.tsx
@@ -15,7 +15,7 @@ const MentalSums = lazy(() => import('components/games/MentalSums'));
 const PandaSequence = lazy(() => import('components/games/PandaSequence'));
 
 export interface FinishedComponentProps {
-  results: ResultMap | null;
+  allMetas: ResultMap | null;
   room: string | null;
   error: CommError | null;
   users: string[];
@@ -52,7 +52,7 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
   }, [comm]);
 
   const {
-    hostMeta, room, error, users, results, myMeta,
+    hostMeta, room, error, users, allMetas, myMeta,
   } = useCommHooks(comm);
 
   const onReadyClick = () => {
@@ -82,7 +82,7 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
         && (
           <FinishedComponent
             {... {
-              results, room, users, error, game,
+              allMetas, room, users, error, game,
             }}
           />
         )}

--- a/Web/src/components/room/CommonRoom.tsx
+++ b/Web/src/components/room/CommonRoom.tsx
@@ -47,10 +47,12 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
   const [isReady, setIsReady] = useState(false);
 
   // general hook to disconnect host from room when he leaves.
-  useEffect(() => () => comm.leaveRoom(), [comm]);
+  useEffect(() => () => {
+    comm.leaveRoom();
+  }, [comm]);
 
   const {
-    hostMeta, room, error, users, results,
+    hostMeta, room, error, users, results, isHost,
   } = useCommHooks(comm);
 
   const onReadyClick = () => {
@@ -59,12 +61,15 @@ const CommonRoom: React.FC<CommonRoomProps> = ({
   };
 
   useEffect(() => {
-    if (hostMeta === null) return;
+    if (hostMeta === null) {
+      if (isHost && room !== null) comm.leaveRoom();
+      return;
+    }
     setGame(hostMeta.game);
     if (hostMeta.state === GameState.FINISHED) {
       setIsReady(false);
     }
-  }, [hostMeta]);
+  }, [comm, hostMeta, isHost, room]);
 
   if (hostMeta === null) {
     return <NoHostComponent />;

--- a/Web/src/components/room/comm/Comm.ts
+++ b/Web/src/components/room/comm/Comm.ts
@@ -22,27 +22,6 @@ export interface CommAttributes {
   myMeta: Meta | null,
 }
 
-export interface Handlers {
-  setRoom: React.Dispatch<React.SetStateAction<string | null>>,
-  setError: React.Dispatch<React.SetStateAction<CommError | null>>,
-  setErrorDescription: React.Dispatch<React.SetStateAction<string | null>>,
-  setUsers: React.Dispatch<React.SetStateAction<string[]>>,
-  setHostMeta: React.Dispatch<React.SetStateAction<HostMeta | null>>,
-  setAllMetas: React.Dispatch<React.SetStateAction<ResultMap | null>>,
-  setMyMeta: React.Dispatch<React.SetStateAction<Meta | null>>,
-}
-
-const noOp = () => { };
-export const noOpHandlers: Handlers = {
-  setRoom: noOp,
-  setError: noOp,
-  setErrorDescription: noOp,
-  setUsers: noOp,
-  setHostMeta: noOp,
-  setAllMetas: noOp,
-  setMyMeta: noOp,
-};
-
 export type PushErrorHandler = (error: PushError, errorDescription: string | null) => void;
 
 /**
@@ -55,7 +34,7 @@ export default interface Comm {
   leaveRoom(): void
 
   // For useCommHooks use
-  _register(handlers: Handlers): void
+  _register(handler: (attributes: CommAttributes) => void): void
   _getAttributes(): CommAttributes
 
   /* RFC #108 */

--- a/Web/src/components/room/comm/Comm.ts
+++ b/Web/src/components/room/comm/Comm.ts
@@ -62,8 +62,8 @@ export default interface Comm {
   sendResult(result: number[], onError?: PushErrorHandler): void
 
   // Host
-  prepare(onError?: PushErrorHandler): void
-  changeGame(game: Game, onError?: PushErrorHandler): void
+  prepare(onOk?: () => void, onError?: PushErrorHandler): void
+  changeGame(game: Game, onOk?: () => void, onError?: PushErrorHandler): void
 
   // For useCommHooks use
   // Client callbacks

--- a/Web/src/components/room/comm/Comm.ts
+++ b/Web/src/components/room/comm/Comm.ts
@@ -1,13 +1,13 @@
 import { CommError, PushError } from './Errors';
-import { HostMeta } from '../database/Meta';
+import Meta, { HostMeta } from '../database/Meta';
 import Game from '../Games';
 
 export interface ResultMap {
-  [name: string]: number[],
+  [clientId: string]: { result: number[], name: string },
 }
 
 export const resultsExist = (res: ResultMap | null): res is ResultMap => Boolean(
-  res && Object.values(res)[0] && Object.values(res)[0].length,
+  res && Object.values(res)[0] && Object.values(res)[0].result.length,
 );
 
 export interface CommAttributes {
@@ -17,7 +17,7 @@ export interface CommAttributes {
   users: string[],
   hostMeta: HostMeta | null,
   results: ResultMap | null,
-  isHost: boolean,
+  myMeta: Meta | null,
 }
 
 export interface Handlers {
@@ -27,7 +27,7 @@ export interface Handlers {
   setUsers: React.Dispatch<React.SetStateAction<string[]>>,
   setHostMeta: React.Dispatch<React.SetStateAction<HostMeta | null>>,
   setResults: React.Dispatch<React.SetStateAction<ResultMap | null>>,
-  setIsHost: React.Dispatch<React.SetStateAction<boolean>>,
+  setMyMeta: React.Dispatch<React.SetStateAction<Meta | null>>,
 }
 
 const noOp = () => { };
@@ -38,7 +38,7 @@ export const noOpHandlers = {
   setUsers: noOp,
   setHostMeta: noOp,
   setResults: noOp,
-  setIsHost: noOp,
+  setMyMeta: noOp,
 };
 
 export type PushErrorHandler = (error: PushError, errorDescription: string | null) => void;

--- a/Web/src/components/room/comm/Comm.ts
+++ b/Web/src/components/room/comm/Comm.ts
@@ -17,6 +17,7 @@ export interface CommAttributes {
   users: string[],
   hostMeta: HostMeta | null,
   results: ResultMap | null,
+  isHost: boolean,
 }
 
 export interface Handlers {
@@ -26,6 +27,7 @@ export interface Handlers {
   setUsers: React.Dispatch<React.SetStateAction<string[]>>,
   setHostMeta: React.Dispatch<React.SetStateAction<HostMeta | null>>,
   setResults: React.Dispatch<React.SetStateAction<ResultMap | null>>,
+  setIsHost: React.Dispatch<React.SetStateAction<boolean>>,
 }
 
 const noOp = () => { };
@@ -36,6 +38,7 @@ export const noOpHandlers = {
   setUsers: noOp,
   setHostMeta: noOp,
   setResults: noOp,
+  setIsHost: noOp,
 };
 
 export type PushErrorHandler = (error: PushError, errorDescription: string | null) => void;

--- a/Web/src/components/room/comm/Comm.ts
+++ b/Web/src/components/room/comm/Comm.ts
@@ -3,12 +3,14 @@ import Meta, { HostMeta } from '../database/Meta';
 import Game from '../Games';
 
 export interface ResultMap {
-  [clientId: string]: { result: number[], name: string },
+  [clientId: string]: Meta,
 }
 
-export const resultsExist = (res: ResultMap | null): res is ResultMap => Boolean(
-  res && Object.values(res)[0] && Object.values(res)[0].result.length,
-);
+export const resultsExist = (res: ResultMap | null): res is ResultMap => {
+  if (res == null) return false;
+  const firstResult = Object.values(res)[0].result;
+  return Boolean(firstResult !== null && firstResult.length);
+};
 
 export interface CommAttributes {
   room: string | null,
@@ -16,7 +18,7 @@ export interface CommAttributes {
   errorDescription: string | null,
   users: string[],
   hostMeta: HostMeta | null,
-  results: ResultMap | null,
+  allMetas: ResultMap | null,
   myMeta: Meta | null,
 }
 
@@ -26,18 +28,18 @@ export interface Handlers {
   setErrorDescription: React.Dispatch<React.SetStateAction<string | null>>,
   setUsers: React.Dispatch<React.SetStateAction<string[]>>,
   setHostMeta: React.Dispatch<React.SetStateAction<HostMeta | null>>,
-  setResults: React.Dispatch<React.SetStateAction<ResultMap | null>>,
+  setAllMetas: React.Dispatch<React.SetStateAction<ResultMap | null>>,
   setMyMeta: React.Dispatch<React.SetStateAction<Meta | null>>,
 }
 
 const noOp = () => { };
-export const noOpHandlers = {
+export const noOpHandlers: Handlers = {
   setRoom: noOp,
   setError: noOp,
   setErrorDescription: noOp,
   setUsers: noOp,
   setHostMeta: noOp,
-  setResults: noOp,
+  setAllMetas: noOp,
   setMyMeta: noOp,
 };
 

--- a/Web/src/components/room/comm/Comm.ts
+++ b/Web/src/components/room/comm/Comm.ts
@@ -59,7 +59,8 @@ export default interface Comm {
   /**
    * Sends current result
    */
-  sendResult(result: number[], onError?: PushErrorHandler): void
+  readyUp(onOk?: () => void, onError?: PushErrorHandler): void
+  sendResult(result: number[], onOk?: () => void, onError?: PushErrorHandler): void
 
   // Host
   prepare(onOk?: () => void, onError?: PushErrorHandler): void

--- a/Web/src/components/room/comm/phoenix/PhoenixComm.ts
+++ b/Web/src/components/room/comm/phoenix/PhoenixComm.ts
@@ -81,6 +81,7 @@ export default class PhoenixComm implements Comm {
 
   _register(handlers: Handlers): void {
     this.handlers = handlers;
+    this.flush();
   }
 
   private getUsers(): string[] {
@@ -100,6 +101,13 @@ export default class PhoenixComm implements Comm {
     );
   }
 
+  private getIsHost(): boolean {
+    if (this.database == null) return false;
+    const meta = this.database.getMyMeta();
+    if (meta == null) return false;
+    return meta.isHost;
+  }
+
   private flush(): void {
     const {
       setError,
@@ -108,6 +116,7 @@ export default class PhoenixComm implements Comm {
       setUsers,
       setHostMeta,
       setResults,
+      setIsHost,
     } = this.handlers;
     if (setError) setError(this.error);
     if (setErrorDescription) setErrorDescription(this.errorDescription);
@@ -115,6 +124,7 @@ export default class PhoenixComm implements Comm {
     if (setUsers) setUsers(this.getUsers());
     if (setHostMeta) setHostMeta(this.getHostMeta());
     if (setResults) setResults(this.getResults());
+    if (setIsHost) setIsHost(this.getIsHost());
   }
 
   private cleanup(): void {
@@ -286,6 +296,7 @@ export default class PhoenixComm implements Comm {
     const users = this.getUsers();
     const hostMeta = this.getHostMeta();
     const results = this.getResults();
+    const isHost = this.getIsHost();
 
     return {
       room,
@@ -294,6 +305,7 @@ export default class PhoenixComm implements Comm {
       users,
       hostMeta,
       results,
+      isHost,
     };
   }
 

--- a/Web/src/components/room/comm/phoenix/PhoenixComm.ts
+++ b/Web/src/components/room/comm/phoenix/PhoenixComm.ts
@@ -94,12 +94,9 @@ export default class PhoenixComm implements Comm {
     return this.database.getHostMeta();
   }
 
-  private getResults(): ResultMap | null {
+  private getAllMetas(): ResultMap | null {
     if (this.database == null) return null;
-    return Object.fromEntries(
-      Object.entries(this.database.getMetas())
-        .map(([clientId, { name, result }]) => [clientId, { name, result: result || [] }]),
-    );
+    return this.database.getMetas();
   }
 
   private getMyMeta(): Meta | null {
@@ -108,22 +105,26 @@ export default class PhoenixComm implements Comm {
   }
 
   private flush(): void {
+    const currentHandlers = this.handlers;
     const {
       setError,
       setErrorDescription,
       setRoom,
       setUsers,
       setHostMeta,
-      setResults,
+      setAllMetas,
       setMyMeta,
-    } = this.handlers;
-    if (setError) setError(this.error);
-    if (setErrorDescription) setErrorDescription(this.errorDescription);
-    if (setRoom) setRoom(this.room);
-    if (setUsers) setUsers(this.getUsers());
-    if (setHostMeta) setHostMeta(this.getHostMeta());
-    if (setResults) setResults(this.getResults());
-    if (setMyMeta) setMyMeta(this.getMyMeta());
+    } = currentHandlers;
+    // Always check whether the handlers has changed
+    if (currentHandlers === this.handlers && setError) setError(this.error);
+    if (currentHandlers === this.handlers && setErrorDescription) {
+      setErrorDescription(this.errorDescription);
+    }
+    if (currentHandlers === this.handlers && setRoom) setRoom(this.room);
+    if (currentHandlers === this.handlers && setUsers) setUsers(this.getUsers());
+    if (currentHandlers === this.handlers && setHostMeta) setHostMeta(this.getHostMeta());
+    if (currentHandlers === this.handlers && setAllMetas) setAllMetas(this.getAllMetas());
+    if (currentHandlers === this.handlers && setMyMeta) setMyMeta(this.getMyMeta());
   }
 
   private cleanup(): void {
@@ -290,7 +291,7 @@ export default class PhoenixComm implements Comm {
     const { room, error, errorDescription } = this;
     const users = this.getUsers();
     const hostMeta = this.getHostMeta();
-    const results = this.getResults();
+    const allMetas = this.getAllMetas();
     const myMeta = this.getMyMeta();
 
     return {
@@ -299,7 +300,7 @@ export default class PhoenixComm implements Comm {
       errorDescription,
       users,
       hostMeta,
-      results,
+      allMetas,
       myMeta,
     };
   }

--- a/Web/src/components/room/comm/phoenix/PhoenixComm.ts
+++ b/Web/src/components/room/comm/phoenix/PhoenixComm.ts
@@ -143,11 +143,7 @@ export default class PhoenixComm implements Comm {
   private handleStateChange(oldState: GameState, newState: GameState): void {
     // State transition handler for client
     if (oldState === GameState.FINISHED && newState === GameState.PREPARE) {
-      // this.pushClientCommand(
-      //   { message: ClientMessage.RESULT, payload: { result: null } },
-      //   noOp,
-      //   noOp,
-      // );
+      // No automatic action on this state transition
     } else if (oldState === GameState.PREPARE && newState === GameState.ONGOING) {
       this.gameStartHandler();
     } else if (oldState === GameState.ONGOING && newState === GameState.FINISHED) {

--- a/Web/src/components/room/comm/phoenix/PhoenixComm.ts
+++ b/Web/src/components/room/comm/phoenix/PhoenixComm.ts
@@ -313,7 +313,7 @@ export default class PhoenixComm implements Comm {
     this.gameStopHandler = handler;
   }
 
-  prepare(onError?: PushErrorHandler): void {
+  prepare(onOk?: () => void, onError?: PushErrorHandler): void {
     if (this.database == null) return;
     if (this.database.hostId !== getClientId()) return;
     const maybeHostMeta = this.database.getHostMeta();
@@ -323,12 +323,12 @@ export default class PhoenixComm implements Comm {
     }
     this.pushHostCommand(
       { message: HostMessage.STATE, payload: { state: GameState.PREPARE } },
-      noOp,
+      onOk || noOp,
       onError || noOp,
     );
   }
 
-  changeGame(game: Game, onError?: PushErrorHandler): void {
+  changeGame(game: Game, onOk?: () => void, onError?: PushErrorHandler): void {
     if (this.database == null) return;
     if (this.database.hostId !== getClientId()) return;
     const maybeHostMeta = this.database.getHostMeta();
@@ -338,7 +338,7 @@ export default class PhoenixComm implements Comm {
     }
     this.pushHostCommand(
       { message: HostMessage.GAME, payload: { game } },
-      noOp,
+      onOk || noOp,
       onError || noOp,
     );
   }

--- a/Web/src/components/room/comm/phoenix/PhoenixComm.ts
+++ b/Web/src/components/room/comm/phoenix/PhoenixComm.ts
@@ -133,11 +133,11 @@ export default class PhoenixComm implements Comm {
   private handleStateChange(oldState: GameState, newState: GameState): void {
     // State transition handler for client
     if (oldState === GameState.FINISHED && newState === GameState.PREPARE) {
-      this.pushClientCommand(
-        { message: ClientMessage.RESULT, payload: { result: null } },
-        noOp,
-        noOp,
-      );
+      // this.pushClientCommand(
+      //   { message: ClientMessage.RESULT, payload: { result: null } },
+      //   noOp,
+      //   noOp,
+      // );
     } else if (oldState === GameState.PREPARE && newState === GameState.ONGOING) {
       this.gameStartHandler();
     } else if (oldState === GameState.ONGOING && newState === GameState.FINISHED) {
@@ -297,10 +297,18 @@ export default class PhoenixComm implements Comm {
     };
   }
 
-  sendResult(result: number[], onError?: PushErrorHandler): void {
+  sendResult(result: number[], onOk?: () => void, onError?: PushErrorHandler): void {
     this.pushClientCommand(
       { message: ClientMessage.RESULT, payload: { result } },
-      noOp,
+      onOk || noOp,
+      onError || noOp,
+    );
+  }
+
+  readyUp(onOk?: () => void, onError?: PushErrorHandler): void {
+    this.pushClientCommand(
+      { message: ClientMessage.RESULT, payload: { result: null } },
+      onOk || noOp,
       onError || noOp,
     );
   }

--- a/Web/src/components/room/comm/phoenix/PhoenixComm.ts
+++ b/Web/src/components/room/comm/phoenix/PhoenixComm.ts
@@ -5,7 +5,7 @@ import isDeployPreview from 'utils/isDeployPreview';
 import getClientId from 'utils/getClientId';
 import Database from 'components/room/database/Database';
 import PhoenixDatabase from 'components/room/database/phoenix/PhoenixDatabase';
-import { HostMeta } from 'components/room/database/Meta';
+import Meta, { HostMeta } from 'components/room/database/Meta';
 import Game from 'components/room/Games';
 import HostCommand, { HostMessage } from '../commands/HostCommand';
 import Comm, {
@@ -97,15 +97,14 @@ export default class PhoenixComm implements Comm {
   private getResults(): ResultMap | null {
     if (this.database == null) return null;
     return Object.fromEntries(
-      Object.values(this.database.getMetas()).map(({ name, result }) => [name, result || []]),
+      Object.entries(this.database.getMetas())
+        .map(([clientId, { name, result }]) => [clientId, { name, result: result || [] }]),
     );
   }
 
-  private getIsHost(): boolean {
-    if (this.database == null) return false;
-    const meta = this.database.getMyMeta();
-    if (meta == null) return false;
-    return meta.isHost;
+  private getMyMeta(): Meta | null {
+    if (this.database == null) return null;
+    return this.database.getMyMeta();
   }
 
   private flush(): void {
@@ -116,7 +115,7 @@ export default class PhoenixComm implements Comm {
       setUsers,
       setHostMeta,
       setResults,
-      setIsHost,
+      setMyMeta,
     } = this.handlers;
     if (setError) setError(this.error);
     if (setErrorDescription) setErrorDescription(this.errorDescription);
@@ -124,7 +123,7 @@ export default class PhoenixComm implements Comm {
     if (setUsers) setUsers(this.getUsers());
     if (setHostMeta) setHostMeta(this.getHostMeta());
     if (setResults) setResults(this.getResults());
-    if (setIsHost) setIsHost(this.getIsHost());
+    if (setMyMeta) setMyMeta(this.getMyMeta());
   }
 
   private cleanup(): void {
@@ -292,7 +291,7 @@ export default class PhoenixComm implements Comm {
     const users = this.getUsers();
     const hostMeta = this.getHostMeta();
     const results = this.getResults();
-    const isHost = this.getIsHost();
+    const myMeta = this.getMyMeta();
 
     return {
       room,
@@ -301,7 +300,7 @@ export default class PhoenixComm implements Comm {
       users,
       hostMeta,
       results,
-      isHost,
+      myMeta,
     };
   }
 

--- a/Web/src/components/room/comm/useCommHooks.ts
+++ b/Web/src/components/room/comm/useCommHooks.ts
@@ -26,7 +26,7 @@ export default function useCommHooks(
     currentAttributes.hostMeta,
   );
   const [results, setResults] = useState<ResultMap | null>(currentAttributes.results);
-  const [isHost, setIsHost] = useState(currentAttributes.isHost);
+  const [myMeta, setMyMeta] = useState(currentAttributes.myMeta);
 
   const handlers: Handlers = {
     setRoom,
@@ -35,7 +35,7 @@ export default function useCommHooks(
     setUsers,
     setHostMeta,
     setResults,
-    setIsHost,
+    setMyMeta,
   };
 
   useEffect(() => {
@@ -59,6 +59,6 @@ export default function useCommHooks(
     users,
     hostMeta,
     results,
-    isHost,
+    myMeta,
   };
 }

--- a/Web/src/components/room/comm/useCommHooks.ts
+++ b/Web/src/components/room/comm/useCommHooks.ts
@@ -1,9 +1,5 @@
 import { useState, useEffect } from 'react';
-import Comm, {
-  Handlers, CommAttributes, noOpHandlers, ResultMap,
-} from './Comm';
-import { CommError } from './Errors';
-import { HostMeta } from '../database/Meta';
+import Comm, { CommAttributes } from './Comm';
 
 const noOp = () => { };
 
@@ -15,36 +11,15 @@ export default function useCommHooks(
   onGameStart: () => void = noOp,
   onGameEnd: () => void = noOp,
 ): CommAttributes {
-  const currentAttributes = comm._getAttributes();
-  const [room, setRoom] = useState<string | null>(currentAttributes.room);
-  const [error, setError] = useState<CommError | null>(currentAttributes.error);
-  const [errorDescription, setErrorDescription] = useState<string | null>(
-    currentAttributes.errorDescription,
-  );
-  const [users, setUsers] = useState<string[]>(currentAttributes.users);
-  const [hostMeta, setHostMeta] = useState<HostMeta | null>(
-    currentAttributes.hostMeta,
-  );
-  const [allMetas, setAllMetas] = useState<ResultMap | null>(currentAttributes.allMetas);
-  const [myMeta, setMyMeta] = useState(currentAttributes.myMeta);
-
-  const handlers: Handlers = {
-    setRoom,
-    setError,
-    setErrorDescription,
-    setUsers,
-    setHostMeta,
-    setAllMetas,
-    setMyMeta,
-  };
+  const [attributes, setAttributes] = useState(comm._getAttributes());
 
   useEffect(() => {
-    comm._register(handlers);
+    comm._register(setAttributes);
     comm._onGameStart(onGameStart);
     comm._onGameEnd(onGameEnd);
 
     return () => {
-      comm._register(noOpHandlers);
+      comm._register(noOp);
       comm._onGameStart(noOp);
       comm._onGameEnd(noOp);
     };
@@ -52,13 +27,5 @@ export default function useCommHooks(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return {
-    room,
-    error,
-    errorDescription,
-    users,
-    hostMeta,
-    allMetas,
-    myMeta,
-  };
+  return attributes;
 }

--- a/Web/src/components/room/comm/useCommHooks.ts
+++ b/Web/src/components/room/comm/useCommHooks.ts
@@ -25,7 +25,7 @@ export default function useCommHooks(
   const [hostMeta, setHostMeta] = useState<HostMeta | null>(
     currentAttributes.hostMeta,
   );
-  const [results, setResults] = useState<ResultMap | null>(currentAttributes.results);
+  const [allMetas, setAllMetas] = useState<ResultMap | null>(currentAttributes.allMetas);
   const [myMeta, setMyMeta] = useState(currentAttributes.myMeta);
 
   const handlers: Handlers = {
@@ -34,7 +34,7 @@ export default function useCommHooks(
     setErrorDescription,
     setUsers,
     setHostMeta,
-    setResults,
+    setAllMetas,
     setMyMeta,
   };
 
@@ -58,7 +58,7 @@ export default function useCommHooks(
     errorDescription,
     users,
     hostMeta,
-    results,
+    allMetas,
     myMeta,
   };
 }

--- a/Web/src/components/room/comm/useCommHooks.ts
+++ b/Web/src/components/room/comm/useCommHooks.ts
@@ -26,6 +26,7 @@ export default function useCommHooks(
     currentAttributes.hostMeta,
   );
   const [results, setResults] = useState<ResultMap | null>(currentAttributes.results);
+  const [isHost, setIsHost] = useState(currentAttributes.isHost);
 
   const handlers: Handlers = {
     setRoom,
@@ -34,6 +35,7 @@ export default function useCommHooks(
     setUsers,
     setHostMeta,
     setResults,
+    setIsHost,
   };
 
   useEffect(() => {
@@ -57,5 +59,6 @@ export default function useCommHooks(
     users,
     hostMeta,
     results,
+    isHost,
   };
 }

--- a/Web/src/components/waiting/index.tsx
+++ b/Web/src/components/waiting/index.tsx
@@ -39,7 +39,7 @@ const ErrorHeading = styled(Heading)`
 `;
 
 const WaitingLobby: React.FC<FinishedComponentProps> = ({
-  room, users, error, results,
+  room, users, error, allMetas,
 }) => {
   const [funMessage, setFunMessage] = useState('Waiting for more people to join...');
 
@@ -55,10 +55,10 @@ const WaitingLobby: React.FC<FinishedComponentProps> = ({
     return <Redirect to="/join" />;
   }
 
-  if (resultsExist(results)) {
+  if (resultsExist(allMetas)) {
     return (
       <WaitingDiv>
-        {Object.entries(results).map(([clientId, { name, result }]) => (
+        {Object.entries(allMetas).map(([clientId, { name, result }]) => (
           <p key={clientId}>{name}: {result}</p>
         ))}
         <Heading>

--- a/Web/src/components/waiting/index.tsx
+++ b/Web/src/components/waiting/index.tsx
@@ -39,7 +39,7 @@ const ErrorHeading = styled(Heading)`
 `;
 
 const WaitingLobby: React.FC<FinishedComponentProps> = ({
-  room, users, error, game, results,
+  room, users, error, results,
 }) => {
   const [funMessage, setFunMessage] = useState('Waiting for more people to join...');
 
@@ -58,8 +58,8 @@ const WaitingLobby: React.FC<FinishedComponentProps> = ({
   if (resultsExist(results)) {
     return (
       <WaitingDiv>
-        {Object.entries(results).map(([name, score]) => (
-          <p>{name}: {score}</p>
+        {Object.entries(results).map(([clientId, { name, result }]) => (
+          <p key={clientId}>{name}: {result}</p>
         ))}
         <Heading>
           Waiting for next game...
@@ -71,9 +71,6 @@ const WaitingLobby: React.FC<FinishedComponentProps> = ({
     <WaitingDiv>
       <Heading>
         {funMessage}
-      </Heading>
-      <Heading>
-        We are going to play {game}
       </Heading>
       <PindaWaving />
     </WaitingDiv>


### PR DESCRIPTION
- Randomise game in each round, but make sure there are no 2 same game in a row
- Change such that each client (as defined in RFC #108) must indicate their readiness through the UI during the `PREPARE` state before proceeding to the `ONGOING` state
- Fix where when host left, non-host cannot just go back and re-join another room
- Refactor `CommAttributes` and `useCommHooks` such that everything in the `Database` class is exposed
- Fix setState on unmounted racey bug by making `flush()` atomic (more or less, to prove please use [PAT](https://www.comp.nus.edu.sg/~pat/OnlineHelp/))
- Add `key` props to some of the elements created in a `Array.map()`