### PR TITLE
Fix broken whatsapp link for whatsapp mobile app

### DIFF
--- a/Web/src/components/create-room/SocialShare.tsx
+++ b/Web/src/components/create-room/SocialShare.tsx
@@ -18,7 +18,7 @@ type SocialShareProps = {
 const SocialShare: React.FC<SocialShareProps> = ({ sharableLink }) => {
   const encodedLink = encodeURIComponent(sharableLink);
   const shareWhatsApp = () => {
-    const url = `https://wa.me/?text=${defaultPromoText}%20${encodedLink}`;
+    const url = `https://api.whatsapp.com/send?text=${defaultPromoText}%20${encodedLink}`;
     window.open(url, '_blank');
   };
 


### PR DESCRIPTION
Fixed by using `api.whatsapp` instead of `wa.me` to send whatsapp msg.
Initially used `wa.me` as per whatsapp recommendation: https://faq.whatsapp.com/en/iphone/26000030/?category=5245251 
But apparently this only works on whatsapp web and is broken on whatsapp mobile app lol

Closes #135 