### PR TITLE
Add babel macros to minify CSS in styled components

### DIFF
--- a/Web/.babel-plugin-macrosrc
+++ b/Web/.babel-plugin-macrosrc
@@ -1,0 +1,8 @@
+{
+  "styledComponents": {
+    "ssr": false,
+    "pure": true,
+    "minify": true,
+    "transpileTemplateLiterals": true
+  }
+}

--- a/Web/.babel-plugin-macrosrc
+++ b/Web/.babel-plugin-macrosrc
@@ -1,6 +1,8 @@
 {
   "styledComponents": {
     "ssr": false,
+    "displayName": false,
+    "fileName": false,
     "pure": true,
     "minify": true,
     "transpileTemplateLiterals": true

--- a/Web/.eslintrc.js
+++ b/Web/.eslintrc.js
@@ -36,6 +36,19 @@ module.exports = {
 
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
+
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [{
+          "name": "styled-components",
+          "message": "Please import from styled-components/macro."
+        }],
+        "patterns": [
+          "!styled-components/macro"
+        ]
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/Web/package.json
+++ b/Web/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.6.0",
     "@typescript-eslint/parser": "^2.6.0",
+    "babel-plugin-macros": "^2.6.1",
     "bundlewatch": "^0.2.5",
     "eslint-config-airbnb-typescript": "^6.0.0",
     "eslint-config-prettier": "^6.5.0",

--- a/Web/src/components/common/BigButton.tsx
+++ b/Web/src/components/common/BigButton.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const BigButton = styled.button`
   background: transparent;

--- a/Web/src/components/common/BrandText.tsx
+++ b/Web/src/components/common/BrandText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const RedText = styled.strong`
   color: var(--red);

--- a/Web/src/components/common/Button.tsx
+++ b/Web/src/components/common/Button.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 type ButtonProps = {
   primary?: boolean;

--- a/Web/src/components/common/LinkButton.tsx
+++ b/Web/src/components/common/LinkButton.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 type ButtonProps = {
   underline?: boolean;

--- a/Web/src/components/common/Loading.tsx
+++ b/Web/src/components/common/Loading.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactLoading from 'react-loading';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { ReactComponent as PindaHeadSVG } from '../../svg/pinda-head-happy.svg';
 
 const LoadingDiv = styled.div`

--- a/Web/src/components/common/Modal.tsx
+++ b/Web/src/components/common/Modal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { smMin } from 'utils/media';
 import Button from './Button';
 

--- a/Web/src/components/common/SocialButton.tsx
+++ b/Web/src/components/common/SocialButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { ReactComponent as TelegramIconSVG } from '../../svg/social/telegram-icon.svg';
 import { ReactComponent as WhatsappIconSVG } from '../../svg/social/whatsapp-icon.svg';
 

--- a/Web/src/components/common/forms/FormElements.tsx
+++ b/Web/src/components/common/forms/FormElements.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import BigButton from 'components/common/BigButton';
 
 const SubmitButton = styled(BigButton)`

--- a/Web/src/components/common/forms/GamePinForm.tsx
+++ b/Web/src/components/common/forms/GamePinForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Form, SubmitButton } from './FormElements';
 
 const StyledPinInput = styled.input`

--- a/Web/src/components/common/forms/UsernameForm.tsx
+++ b/Web/src/components/common/forms/UsernameForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Form, SubmitButton } from './FormElements';
 
 const StyledNameInput = styled.input`

--- a/Web/src/components/create-room/CreateRoomPage.tsx
+++ b/Web/src/components/create-room/CreateRoomPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import CommContext from 'components/room/comm/CommContext';
 import { CommAttributes } from 'components/room/comm/Comm';
 import UsernameForm from 'components/common/forms/UsernameForm';

--- a/Web/src/components/create-room/HostRoom.tsx
+++ b/Web/src/components/create-room/HostRoom.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { Link, Redirect } from 'react-router-dom';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import BigButton from 'components/common/BigButton';
 import CommContext from 'components/room/comm/CommContext';
 import CommonRoom, { FinishedComponentProps } from 'components/room/CommonRoom';

--- a/Web/src/components/create-room/NumPlayers.tsx
+++ b/Web/src/components/create-room/NumPlayers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import { Users, Icon } from 'react-feather';
 import { mdMin } from '../../utils/media';
 

--- a/Web/src/components/create-room/QrCode.tsx
+++ b/Web/src/components/create-room/QrCode.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import QRCode from 'qrcode.react';
 
 const QrContainer = styled.div`

--- a/Web/src/components/create-room/RoomMembers.tsx
+++ b/Web/src/components/create-room/RoomMembers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ListRowProps } from 'react-virtualized';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { WindowScrollVirtualizedList } from 'components/common/VirtualizedList';
 import { smMin } from 'utils/media';
 

--- a/Web/src/components/create-room/SocialShare.tsx
+++ b/Web/src/components/create-room/SocialShare.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { TelegramButton, WhatsappButton } from '../common/SocialButton';
 
 const defaultPromoText = encodeURIComponent('Join a new game on Pinda!');

--- a/Web/src/components/games/BalloonShake/GameDisplay.tsx
+++ b/Web/src/components/games/BalloonShake/GameDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import TimerDisplay from 'components/games/TimerDisplay';
 import { ReactComponent as Balloon } from 'svg/balloon.svg';
 

--- a/Web/src/components/games/BalloonShake/GamePrep.tsx
+++ b/Web/src/components/games/BalloonShake/GamePrep.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Button from 'components/common/Button';
 import BigButton from 'components/common/BigButton';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { ReactComponent as ShockedPindaSVG } from 'svg/pinda-shocked-badge.svg';
 import { MotionPermission } from '../GameStates';
 
@@ -29,36 +29,36 @@ const GamePrep: React.FC<IProps> = ({
 }) => (
   <Container>
     {permission === MotionPermission.NOT_SET && !showPermissionRequest
-      && (
-        <h3>
-          Checking if you can play the game...
-        </h3>
-      )}
+        && (
+          <h3>
+            Checking if you can play the game...
+          </h3>
+        )}
     {permission === MotionPermission.NOT_SET && showPermissionRequest
-      && (
-        <Button onClick={() => requestPermissionCallback()} type="button">
-          Set Permission
-        </Button>
-      )}
+        && (
+          <Button onClick={() => requestPermissionCallback()} type="button">
+            Set Permission
+          </Button>
+        )}
     {permission === MotionPermission.GRANTED
-      && (
-        <BigButton onClick={startGame} type="button">
-          Start Game!
-        </BigButton>
-      )}
+        && (
+          <BigButton onClick={startGame} type="button">
+            Start Game!
+          </BigButton>
+        )}
     {permission === MotionPermission.DENIED
-      && (
-        <>
-          <ShockedPindaSVG />
-          <h1>
-            Uh Oh!
-          </h1>
-          <p>
-            Permissions to your device&apos;s motion sensor was not granted, so
-            you can&apos;t play this game.
-          </p>
-        </>
-      )}
+        && (
+          <>
+            <ShockedPindaSVG />
+            <h1>
+              Uh Oh!
+            </h1>
+            <p>
+              Permissions to your device&apos;s motion sensor was not granted, so
+              you can&apos;t play this game.
+            </p>
+          </>
+        )}
   </Container>
 );
 

--- a/Web/src/components/games/BalloonShake/GameResults.tsx
+++ b/Web/src/components/games/BalloonShake/GameResults.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import CommContext from 'components/room/comm/CommContext';
 
 const Container = styled.div`

--- a/Web/src/components/games/Countdown.tsx
+++ b/Web/src/components/games/Countdown.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { createTimerObservable } from './rxhelpers';
 
 const CountdownDiv = styled.div`

--- a/Web/src/components/games/GameInstructions.tsx
+++ b/Web/src/components/games/GameInstructions.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { smMin } from 'utils/media';
 
 const InstructionsDiv = styled.div`

--- a/Web/src/components/games/MentalSums/GameResults.tsx
+++ b/Web/src/components/games/MentalSums/GameResults.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import CommContext from 'components/room/comm/CommContext';
 
 const Container = styled.div`

--- a/Web/src/components/games/MentalSums/MentalSumsGame.tsx
+++ b/Web/src/components/games/MentalSums/MentalSumsGame.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import seedrandom from 'seedrandom';
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import { smMin } from 'utils/media';
 import { useQuestionStream } from './ProblemGen';
 import TimerDisplay from '../TimerDisplay';

--- a/Web/src/components/games/MentalSums/NumKeypad.tsx
+++ b/Web/src/components/games/MentalSums/NumKeypad.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const NUMPAD_KEYS = ['7', '8', '9', '4', '5', '6', '1', '2', '3', '-', '0'];
 

--- a/Web/src/components/games/PandaSequence/FeedbackModal.tsx
+++ b/Web/src/components/games/PandaSequence/FeedbackModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import Modal from 'components/common/Modal';
 import { Check, X } from 'react-feather';
 

--- a/Web/src/components/games/PandaSequence/GameDisplay.tsx
+++ b/Web/src/components/games/PandaSequence/GameDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled, { ThemeProvider } from 'styled-components';
+import styled, { ThemeProvider } from 'styled-components/macro';
 import TimerDisplay from 'components/games/TimerDisplay';
 import { smMin } from 'utils/media';
 import FeedbackModal from './FeedbackModal';

--- a/Web/src/components/games/PandaSequence/GameResults.tsx
+++ b/Web/src/components/games/PandaSequence/GameResults.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import CommContext from 'components/room/comm/CommContext';
 
 const Container = styled.div`

--- a/Web/src/components/games/PandaSequence/PandaPot.tsx
+++ b/Web/src/components/games/PandaSequence/PandaPot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import { jump } from 'utils/animations';
 import { ReactComponent as FlowerPotSVG } from 'svg/flower-pot.svg';
 import { ReactComponent as PandaHeadSVG } from 'svg/panda-head-flower.svg';

--- a/Web/src/components/games/TimerDisplay.tsx
+++ b/Web/src/components/games/TimerDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 const TimerDiv = styled.div`
   display: flex;

--- a/Web/src/components/join-room/JoinRoomForm.tsx
+++ b/Web/src/components/join-room/JoinRoomForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import LinkButton from 'components/common/LinkButton';
 import { MotionPermission } from 'components/games/GameStates';
 import GamePinForm from 'components/common/forms/GamePinForm';

--- a/Web/src/components/join-room/JoinRoomPage.tsx
+++ b/Web/src/components/join-room/JoinRoomPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { MotionPermission } from 'components/games/GameStates';
 import CommContext from 'components/room/comm/CommContext';
 import { CommAttributes } from 'components/room/comm/Comm';

--- a/Web/src/components/join-room/ParticipantRoom.tsx
+++ b/Web/src/components/join-room/ParticipantRoom.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Link } from 'react-router-dom';
 import { ReactComponent as PindaWavingSVG } from 'svg/pinda-waving-badge.svg';
 import CommonRoom, { FinishedComponentProps } from 'components/room/CommonRoom';

--- a/Web/src/components/landing/DetailsContent.tsx
+++ b/Web/src/components/landing/DetailsContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import BrandText from '../common/BrandText';
 import StartNewGameButton from './StartNewGameButton';
 

--- a/Web/src/components/landing/HeaderContent.tsx
+++ b/Web/src/components/landing/HeaderContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import BrandText from '../common/BrandText';
 import StartNewGameButton from './StartNewGameButton';
 import { mdMin } from '../../utils/media';

--- a/Web/src/components/landing/IntroductionContent.tsx
+++ b/Web/src/components/landing/IntroductionContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import BrandText from '../common/BrandText';
 import StartNewGameButton from './StartNewGameButton';
 import { mdMin } from '../../utils/media';

--- a/Web/src/components/landing/NavBar.tsx
+++ b/Web/src/components/landing/NavBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Link } from 'react-router-dom';
 import Button from '../common/Button';
 

--- a/Web/src/components/landing/index.tsx
+++ b/Web/src/components/landing/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import HeaderContent from './HeaderContent';
 import IntroductionContent from './IntroductionContent';
 import DetailsContent from './DetailsContent';

--- a/Web/src/components/results-leaderboard/Leaderboard.tsx
+++ b/Web/src/components/results-leaderboard/Leaderboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { ChevronUp, Icon } from 'react-feather';
 import getClientId from 'utils/getClientId';
 import { smMin } from 'utils/media';

--- a/Web/src/components/results-leaderboard/Results.tsx
+++ b/Web/src/components/results-leaderboard/Results.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { ChevronDown, Icon } from 'react-feather';
 
 interface ResultsProps {

--- a/Web/src/utils/animations.ts
+++ b/Web/src/utils/animations.ts
@@ -1,4 +1,4 @@
-import { keyframes } from 'styled-components';
+import { keyframes } from 'styled-components/macro';
 
 export const blinkRed = keyframes`
   0% {

--- a/Web/yarn.lock
+++ b/Web/yarn.lock
@@ -2068,7 +2068,7 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@2.6.1:
+babel-plugin-macros@2.6.1, babel-plugin-macros@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz#41f7ead616fc36f6a93180e89697f69f51671181"
   integrity sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==


### PR DESCRIPTION
Removes 3KB of our gzipped bundle size by minifying CSS in styled components

Removes all comments, spaces and what not

From now on, please import from `'styled-components/macro'` (enforced by ESLint)