### PR TITLE
Provide better error message when connecting to empty room as non-host

### DIFF
--- a/api/lib/api_web/channels/room_channel.ex
+++ b/api/lib/api_web/channels/room_channel.ex
@@ -48,6 +48,10 @@ defmodule ApiWeb.RoomChannel do
     {:ok, socket}
   end
 
+  defp join(_, %{"name" => name}, _, :host) when is_binary(name) do
+    {:error, %{reason: "Room with that PIN does not exist"}}
+  end
+
   defp join(_topic, payload = %{"name" => name}, socket, :non_host) when is_binary(name) do
     send(self(), {:after_join, :non_host, payload})
     {:ok, socket}

--- a/api/test/api_web/channels/room_channel_test.exs
+++ b/api/test/api_web/channels/room_channel_test.exs
@@ -57,10 +57,12 @@ defmodule ApiWeb.RoomChannelTest do
                  socket(ApiWeb.UserSocket, "", %{client_id: @host_client_id})
                  |> join(RoomChannel, "room:#{pin}")
 
-        assert {:error, %{reason: "Bad request"}} =
+        # Connecting like a non-host results in appropriate error message
+        assert {:error, %{reason: "Room with that PIN does not exist"}} =
                  socket(ApiWeb.UserSocket, "", %{client_id: @host_client_id})
                  |> join(RoomChannel, "room:#{pin}", %{"name" => @host_name})
 
+        # Good
         assert {:ok, %{}, socket} =
                  socket(ApiWeb.UserSocket, "", %{client_id: @host_client_id})
                  |> join(RoomChannel, "room:#{pin}", %{"name" => @host_name, "game" => @game})
@@ -150,6 +152,11 @@ defmodule ApiWeb.RoomChannelTest do
         assert {:error, %{reason: "Existing connection"}} =
                  socket(ApiWeb.UserSocket, "", %{client_id: @non_host_client_id})
                  |> join(RoomChannel, "room:#{pin}", %{"name" => @non_host_name})
+
+        # And invalid pin has an appropriate error message
+        assert {:error, %{reason: "Room with that PIN does not exist"}} =
+                 socket(ApiWeb.UserSocket, "", %{client_id: @non_host_client_id})
+                 |> join(RoomChannel, "room:0000", %{"name" => @non_host_name})
 
         send(tester_pid, {:non_host, :host, :connected})
 


### PR DESCRIPTION
Resolves #243 

Deployed to staging.

There's no change to frontend, so no deploy preview. Can try use the other deploy preview: https://deploy-preview-239--pinda-fun.netlify.com

<img width="460" alt="image" src="https://user-images.githubusercontent.com/11135744/68582959-fb9ab300-04b6-11ea-98b5-502f57ea1e2c.png">
