### PR TITLE
fix timeout modal

### DIFF
--- a/Web/src/components/games/PandaSequence/index.tsx
+++ b/Web/src/components/games/PandaSequence/index.tsx
@@ -44,7 +44,10 @@ const PandaSequence: React.FC<PandaSequenceProps> = ({ seed }) => {
     const timerSub = timer.subscribe(
       (left) => setSecondsLeft(left),
       null,
-      () => setGameState(GameState.TIMES_UP),
+      () => {
+        setFeedback(() => Feedback.NONE);
+        setGameState(GameState.TIMES_UP);
+      },
     );
     setSequence((oldSeq) => generate(oldSeq, generator));
     return () => timerSub.unsubscribe();


### PR DESCRIPTION
Some users have been facing a bug where they become unable to scroll after a game of Peek-a-boo. This is due to the feedback modal triggering and the game timing out before the feedback modal is dismissed. This results in a state where the background div is non-scrollable as it assumes that a modal is still present.

Fix is to change feedback state for the modal to NONE when game times out.